### PR TITLE
Update Woche-02.md

### DIFF
--- a/Woche-02.md
+++ b/Woche-02.md
@@ -40,6 +40,16 @@ Leider würde an dieser Stelle eine weitreichende Diskussion der Funktionsweise 
 
 Seit Version 4.10 sind die Methoden `compile`, `runtime`, `testCompile`, `testRuntime` bei gradle als despracted markiert und wurden mit der aktuellsten Version entfernt. Stattdessen sollte `implementation`, `runtimeOnly`, `testImplementation` und `testRuntimeOnly` verwendet werden. 
 
-Im Video werden noch die alten Methoden verwendet, dies kann dazu führen, das die Github Actions fehlschlagen, da Github die neueste Gradle Version benutzt. 
+Im Video werden noch die alten Methoden verwendet, dies kann dazu führen, das die Github Actions fehlschlagen, da Github die neueste Gradle Version benutzt. Sollte dies geschehen, kann in build.gradle die Zeile
 
+```
+    compile 'commons-cli:commons-cli:1.4'
+```
 
+durch
+
+```
+    implementation 'commons-cli:commons-cli:1.4'
+```
+
+ersetzt werden, damit funktioniert es sowohl unter gradle 6 also auch unter gradle 7.

--- a/Woche-02.md
+++ b/Woche-02.md
@@ -35,3 +35,11 @@ Um den Umgang mit git zu üben, arbeiten wir in diesem Modul mit github classroo
 ## Die Funktionsweise von git
 
 Leider würde an dieser Stelle eine weitreichende Diskussion der Funktionsweise von git den Rahmen sprengen - eventuell lässt sich das im zweiten Projekt unterbringen. [Hier](https://www.youtube.com/watch?v=8oRjP8yj2Wo&list=PLg7s6cbtAD165JTRsXh8ofwRw0PqUnkVH) gibt es aber für die Wissbegierigen unter Ihnen eine empfehlenswerte kurze Youtube-Serie, die die Motivation für und Funktionsweise von git beschreibt.
+
+## Bemerkung bezüglich hinzufügen von dependencies mit der build.gradle Datei
+
+Seit Version 4.10 sind die Methoden `compile`, `runtime`, `testCompile`, `testRuntime` bei gradle als despracted markiert und wurden mit der aktuellsten Version entfernt. Stattdessen sollte `implementation`, `runtimeOnly`, `testImplementation` und `testRuntimeOnly` verwendet werden. 
+
+Im Video werden noch die alten Methoden verwendet, dies kann dazu führen, das die Github Actions fehlschlagen, da Github die neueste Gradle Version benutzt. 
+
+


### PR DESCRIPTION
Bei der neuesten Aufgabe ist mir aufgefallen, das alle Tests bei mir lokal durchlaufen, aber bei Github Actions fehlschlagen. Dabei habe ich gesehen, das github Gradle 7 verwendet. Bei Gradle 7 wurden aber einige Methoden entfernt, siehe Notiz in der Woche-02.md

Viele Grüße
Moritz Kreemke